### PR TITLE
Adding proxy_redirect to the default.ssl.conf

### DIFF
--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -16,6 +16,7 @@ server {
     <% if domain.upstream %>
     location / {
         proxy_pass <%= domain.upstream %>;
+        proxy_redirect http:// $scheme://;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Adding one `proxy_redirect` line to the default.ssl.conf.erb template. This configuration fixes changes redirects to use https. Derived from http://serverfault.com/a/372889

nginx's default `proxy_redirect` behavior will not rewrite the scheme in the Location header e.g. http://my.example.com/path. Modern browsers will not load [mixed-content](https://developer.mozilla.org/en-US/docs/Security/MixedContent/How_to_fix_website_with_mixed_content) since the site was loaded over HTTPS but attempts to request content over HTTP.

I understand that users can provide custom nginx configurations, but this seemed like a good default consistent with the project's goals.