### PR TITLE
Allow settings client_max_body_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ KEEPALIVE_TIMEOUT=65
 GZIP=off
 SERVER_NAMES_HASH_MAX_SIZE=512
 SERVER_NAMES_HASH_BUCKET_SIZE=32        # defaults to 32 or 64 based on your CPU
+CLIENT_MAX_BODY_SIZE=1M                 # 0 disables checking request body size
 ```
 
 ### Override Nginx Configuration Files

--- a/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
@@ -31,6 +31,9 @@ http {
     <% if ENV['SERVER_NAMES_HASH_BUCKET_SIZE'] %>
     server_names_hash_bucket_size <%= ENV['SERVER_NAMES_HASH_BUCKET_SIZE'] %>;
     <% end %>
+    <% if ENV['CLIENT_MAX_BODY_SIZE'] %>
+    client_max_body_size <%= ENV['CLIENT_MAX_BODY_SIZE'] %>;
+    <% end %>
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
When using nginx as a proxy, the client_max_body_size parameter can prevent some software (Like ownCloud) from allowing users to upload, by sending a 413 when the client tries to POST more than the default value (1M).

This allows setting a custom value or disabling it entirely (By setting 0 as value).

Nginx documentation: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size