### PR TITLE
Stop nginx from being smart about hosts not being up

### DIFF
--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -15,7 +15,8 @@ server {
 
     <% if domain.upstream %>
     location / {
-        proxy_pass <%= domain.upstream %>;
+        set $upstream <%= domain.upstream %>;
+        proxy_pass $upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Took this from another project where I am using docker containers, over there the directive looks like this:

```
set $upstream_dashboard dashboard;
proxy_pass http://$upstream_dashboard:8080;
```

So I am not sure if it will work when putting the complete upstream in that variable, also, I am not sure how these variables are scoped and what will happen when we have multiple of them (with the same name) in a file.

But who knows?

This might just work and if so, will solve the following problem:

`nginx: [emerg] host not found in upstream "BLABLA" in /etc/nginx/conf.d/BLABLA.ssl.conf:18`