### PR TITLE
Adds environment variables for proxy buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ SERVER_TOKENS=off
 SERVER_NAMES_HASH_MAX_SIZE=512
 SERVER_NAMES_HASH_BUCKET_SIZE=32        # defaults to 32 or 64 based on your CPU
 CLIENT_MAX_BODY_SIZE=1M                 # 0 disables checking request body size
+PROXY_BUFFERS="8 4k"                    # Either 4k or 8k depending on the platform
+PROXY_BUFFER_SIZE="4k"                  # Either 4k or 8k depending on the platform
 ```
 
 You can also add

--- a/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
@@ -41,6 +41,12 @@ http {
     <% if ENV['CLIENT_MAX_BODY_SIZE'] %>
     client_max_body_size <%= ENV['CLIENT_MAX_BODY_SIZE'] %>;
     <% end %>
+    <% if ENV['PROXY_BUFFERS'] %>
+    proxy_buffers <%= ENV['PROXY_BUFFERS'] %>;
+    <% end %>
+    <% if ENV['PROXY_BUFFER_SIZE'] %>
+    proxy_buffer_size <%= ENV['PROXY_BUFFER_SIZE'] %>;
+    <% end %>
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Hi @SteveLTN 

I've a case with a site where I'm getting 502s due to the upstream headers being too big. I've added the code to allow setting proxy buffers using environment variables. 

I was trying to think of a more general solution for this – I've got a couple of ideas, but nothing that took 5 minutes to implement. Might think about it for the future.
