### PR TITLE
Add resolver config with docker defaults

### DIFF
--- a/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
@@ -47,6 +47,10 @@ http {
     <% if ENV['PROXY_BUFFER_SIZE'] %>
     proxy_buffer_size <%= ENV['PROXY_BUFFER_SIZE'] %>;
     <% end %>
+    
+    <% if ENV['RESOLVER_ON'] %>
+    resolver <% ENV['RESOLVER_IP'] || '127.0.0.11' %> valid=<% ENV['RESOLVER_VALID'] || '60s' %>;
+    <% end %>
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
This adds the resolver config with docker defaults.

When a container takes longer to start, and nginx cannot reach it when it starts, it will fail to serve that service.

This change sets up the resolver (defaulting to the docker DNS ip and a 60 seconds "cache" validity of the records), which avoids this issue.

I made it so that it can be enabled with a flag & configured further.