### PR TITLE
Handle null domains

### DIFF
--- a/fs_overlay/opt/certs_manager/lib/na_config.rb
+++ b/fs_overlay/opt/certs_manager/lib/na_config.rb
@@ -46,7 +46,7 @@ module NAConfig
   private
 
   def self.parse(domain_desc)
-    domain_desc.split(',').map(&:strip).delete_if{ |s| s == "" }.map do |descriptor|
+    domain_desc.split(',').map(&:strip).delete_if{ |s| s == "" }.delete_if{ |s| s[0..1] == '->' }.map do |descriptor|
       Domain.new(descriptor)
     end
   end


### PR DESCRIPTION
Tweaked `na_config` to remove domains that start with `->` (i.e. domains with a VIRTUAL_HOST set to a nil string) by using `delete_if{ |s| s[0..1] == '->' }`.

I was having trouble working out how to do an appropriate console log to notify the user of the problem, but at least it avoids nasty errors that potentially bring down the entire network.

Forgive my lack of Ruby knowledge!
