### PR TITLE
Add proxy_http_version to support the Upgrade header

### DIFF
--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -22,6 +22,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
 
         <% if ENV['WEBSOCKET'] && ENV['WEBSOCKET'].downcase == 'true' %>
+        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_read_timeout 2h;


### PR DESCRIPTION
The Upgrade header is only supported by HTTP/1.1 but nginx uses HTTP/1.0 by default. This breaks some services which rely on websockets. So `proxy_http_version` hast to be set to `1.1` if `WEBSOCKET` environment variable is set to `true`.