### PR TITLE
Add option to avoid nginx DNS caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.11
+FROM nginx:1.12.2
 
 MAINTAINER Weiyan Shao "lighteningman@gmail.com"
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,13 @@ WEBSOCKET=true
 
 to make HTTPS-PORTAL proxy WEBSOCKET connections.
 
+To avoid nginx DNS caching activate dynamic upstream
+
+```
+RESOLVER="127.0.0.11 ipv6=off valid=30s"
+DYNAMIC_UPSTREAM=true
+```
+
 ### Override Nginx Configuration Files
 
 You can override default nginx settings by providing a config segment of

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -20,7 +20,12 @@ server {
 
     <% if domain.upstream %>
     location / {
+        <% if ENV['DYNAMIC_UPSTREAM'] && ENV['DYNAMIC_UPSTREAM'].downcase == 'true' %>
+        set $backend <%= domain.upstream %>;
+        proxy_pass $backend;
+        <% else %>
         proxy_pass <%= domain.upstream %>;
+        <% end %>
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
nginx doesn't renew resolved IPs. Therefore services can't be reached if they are scheduled or recreated on another node.