### PR TITLE
Upgrade acme-tiny to 4.0.3 + disable self-check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV DOCKER_GEN_VERSION 0.7.3
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v1.11.0.1/s6-overlay-amd64.tar.gz /tmp/
 ADD https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz /tmp/
-ADD https://raw.githubusercontent.com/diafygi/acme-tiny/19b274cf38544ad9ccc69aa140969c30c4e0d8fd/acme_tiny.py /bin/acme_tiny
+ADD https://raw.githubusercontent.com/diafygi/acme-tiny/ad7802f1c47e5c31a8e7dfedb3577e6c7d04844a/acme_tiny.py /bin/acme_tiny
 
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / &&\
     tar -C /bin -xzf /tmp/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz && \

--- a/fs_overlay/opt/certs_manager/lib/acme.rb
+++ b/fs_overlay/opt/certs_manager/lib/acme.rb
@@ -25,6 +25,7 @@ module ACME
           --account-key /var/lib/https-portal/account.key \
           --csr #{domain.csr_path} \
           --acme-dir /var/www/default/challenges/ \
+          --disable-check \
           --directory-url #{domain.ca} > #{domain.ongoing_cert_path}
       EOC
 

--- a/fs_overlay/opt/certs_manager/lib/acme.rb
+++ b/fs_overlay/opt/certs_manager/lib/acme.rb
@@ -25,7 +25,7 @@ module ACME
           --account-key /var/lib/https-portal/account.key \
           --csr #{domain.csr_path} \
           --acme-dir /var/www/default/challenges/ \
-          --ca #{domain.ca} > #{domain.ongoing_cert_path}
+          --directory-url #{domain.ca} > #{domain.ongoing_cert_path}
       EOC
 
       raise FailedToSignException unless system(command)

--- a/fs_overlay/opt/certs_manager/models/domain.rb
+++ b/fs_overlay/opt/certs_manager/models/domain.rb
@@ -54,11 +54,11 @@ class Domain
   def ca
     case stage
     when 'production'
-      'https://acme-v01.api.letsencrypt.org'
+      'https://acme-v02.api.letsencrypt.org/directory'
     when 'local'
       nil
     when 'staging'
-      'https://acme-staging.api.letsencrypt.org'
+      'https://acme-staging-v02.api.letsencrypt.org/directory'
     end
   end
 


### PR DESCRIPTION
Fixes #116.

Ran into an issue very similar to #116  and I was able to fix it by upgrading acme-tiny to 4.0.3 and adding the disable-check flag passed to the acme client.