### PR TITLE
Add option to manually set genrsa numbits

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,18 @@ Another example can be found [here](/examples/custom_config).
 
 If you want to make an Nginx configuration that will be used by all sites, you can overwrite `/var/lib/nginx-conf/default.conf.erb` or `/var/lib/nginx-conf/default.ssl.conf.erb`. These two files will be propagated to each site if the site-specific configuration files are not provided.
 
+### Manually Set RSA Private Key Length
+
+By default, HTTPS-PORTAL generate `2048` bits long RSA private key.  
+However, you can manually set RSA private key length (`numbits` of `openssl genrsa` command) through `NUMBITS` environment variable.
+
+```yaml
+https-portal:
+  # ...
+  environment:
+    NUMBITS: '4096'
+```
+
 ## How It Works
 
 It:

--- a/fs_overlay/opt/certs_manager/lib/open_ssl.rb
+++ b/fs_overlay/opt/certs_manager/lib/open_ssl.rb
@@ -9,7 +9,7 @@ module OpenSSL
 
   def self.ensure_domain_key(domain)
     unless File.exist? domain.key_path
-      system "openssl genrsa 2048 > #{domain.key_path}"
+      system "openssl genrsa #{ENV['NUMBITS'] && ENV['NUMBITS'] =~ /^[0-9]+$/ ? ENV['NUMBITS'] : 2048} > #{domain.key_path}"
     end
   end
 

--- a/fs_overlay/opt/certs_manager/lib/open_ssl.rb
+++ b/fs_overlay/opt/certs_manager/lib/open_ssl.rb
@@ -9,7 +9,7 @@ module OpenSSL
 
   def self.ensure_domain_key(domain)
     unless File.exist? domain.key_path
-      system "openssl genrsa #{ENV['NUMBITS'] && ENV['NUMBITS'] =~ /^[0-9]+$/ ? ENV['NUMBITS'] : 2048} > #{domain.key_path}"
+      system "openssl genrsa #{ENV['NUMBITS'] =~ /^[0-9]+$/ ? ENV['NUMBITS'] : 2048} > #{domain.key_path}"
     end
   end
 


### PR DESCRIPTION
We can manually set `numbits` of `openssl genrsa` command like this:
```yml
https-portal:
  # ...
  environment:
    NUMBITS: '4096'
```