### PR TITLE
F20190119 nginx grpc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ If you want to make an Nginx configuration that will be used by all sites, you c
 https-portal:
   # ...
   environment:
-    DOMAINS: "my.grpc.service.domain.com -> grpc://grpc:port"
+    DOMAINS: 'my.grpc.service.domain.com -> grpc://grpc:port'
 ```
 
 ### Manually Set RSA Private Key Length

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Docker Hub page:
   - [Advanced Usage](#advanced-usage)
     - [Configure Nginx through Environment Variables](#configure-nginx-through-environment-variables)
     - [Override Nginx Configuration Files](#override-nginx-configuration-files)
+    - [GRPC Support](#grpc-support)
   - [How It Works](#how-it-works)
   - [About Rate Limits of Let's Encrypt](#about-rate-limits-of-lets-encrypt)
   - [Troubleshooting](#troubleshooting)
@@ -366,7 +367,7 @@ For valid IP values see [Nginx allow](http://nginx.org/en/docs/http/ngx_http_acc
 
 ### Configure Nginx through Environment Variables
 
-In case you need to change Nginx's default parameters, 
+In case you need to change Nginx's default parameters,
 there are several additional environment variables that you can use to config Nginx.
 They correspond to the configuration options that you would normally put in `nginx.conf`.
 The following are the available params with their default values:
@@ -429,6 +430,15 @@ Another example can be found [here](/examples/custom_config).
 
 If you want to make an Nginx configuration that will be used by all sites, you can overwrite `/var/lib/nginx-conf/default.conf.erb` or `/var/lib/nginx-conf/default.ssl.conf.erb`. These two files will be propagated to each site if the site-specific configuration files are not provided.
 
+### GRPC Support
+
+```yaml
+https-portal:
+  # ...
+  environment:
+    DOMAINS: "my.grpc.service.domain.com -> grpc://grpc:port"
+```
+
 ### Manually Set RSA Private Key Length
 
 By default, HTTPS-PORTAL generate `2048` bits long RSA private key.  
@@ -490,9 +500,9 @@ https-portal:
     FORCE_RENEW: 'true' # <-- here
 ```
 
-This is because with ACME v2 returns the full chain instead of a partial chain 
-with ACME v1. If you have old certificates stored, HTTPS-PORTAl may not be able 
-to handle the case correctly. If you run into this issue, just `FORCE_RENEW` to 
+This is because with ACME v2 returns the full chain instead of a partial chain
+with ACME v1. If you have old certificates stored, HTTPS-PORTAl may not be able
+to handle the case correctly. If you run into this issue, just `FORCE_RENEW` to
 obtain a new set of certificates.
 
 ## Credits

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl http2 1443;
+    listen 443 ssl http2;
     server_name <%= domain.name %>;
 
     ssl on;

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -1,12 +1,12 @@
 server {
-    listen 443 ssl http2;
+    listen 443 ssl http2 1443;
     server_name <%= domain.name %>;
 
     ssl on;
     ssl_certificate <%= domain.chained_cert_path %>;
     ssl_certificate_key <%= domain.key_path %>;
 
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols       TLSv1.1 TLSv1.2 TLSv1.3;
     ssl_session_cache shared:SSL:50m;
     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA;
     ssl_prefer_server_ciphers on;
@@ -36,7 +36,11 @@ server {
         set $backend <%= domain.upstream %>;
         proxy_pass $backend;
         <% else %>
+        <% if domain.upstream =~ /grpc/ %>
+        grpc_pass <%= domain.upstream %>;
+        <% else %>
         proxy_pass <%= domain.upstream %>;
+        <% end %>
         <% end %>
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Now with the new nginx 1.14.2 you also can use this container as grpc ssl termination endpoint