### PR TITLE
Add IPv6 listening option

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,16 @@ You can use the follow environment variable to set HSTS header.
 HSTS_MAX_AGE=60  # in seconds
 ```
 
+#### IPv6 connectivity
+
+**Notice:** IPv6 is only supported on Linux hosts.
+
+You can enable IPv6 connection using the following variable:
+
+```
+LISTEN_IPV6=true
+```
+
 ### Override Nginx Configuration Files
 
 You can override default nginx settings by providing a config segment of

--- a/fs_overlay/var/lib/nginx-conf/default.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.conf.erb
@@ -1,5 +1,8 @@
 server {
     listen       80;
+    <% if ENV['LISTEN_IPV6'] && ENV['LISTEN_IPV6'].downcase == 'true' %>
+    listen       [::]:80;
+    <% end %>
     server_name  <%= domain.name %>;
 
     <% if domain.redirect_target_url %>

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -1,5 +1,8 @@
 server {
     listen 443 ssl http2;
+    <% if ENV['LISTEN_IPV6'] && ENV['LISTEN_IPV6'].downcase == 'true' %>
+    listen [::]:443 ssl http2;
+    <% end %>
     server_name <%= domain.name %>;
 
     ssl_certificate <%= domain.chained_cert_path %>;


### PR DESCRIPTION
I have added an environment variable to enable listening on IPv6.

```
services:
  https-portal:
    # ...
    environment:
      LISTEN_IPV6: "true"
```