### PR TITLE
Modify Dockerfile to allow docker cross build (fix #152)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:1.17.3
+ARG  DIST=nginx:1.17.3
+FROM $DIST
+ARG  ARCH=amd64
 
 WORKDIR /root
 
@@ -6,14 +8,14 @@ ENV S6_OVERLAY_VERSION v1.22.1.0
 ENV DOCKER_GEN_VERSION 0.7.4
 ENV ACME_TINY_VERSION 4.1.0
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz /tmp/
-ADD https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz /tmp/
+ADD https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/s6-overlay-$ARCH.tar.gz /tmp/
+ADD https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-$ARCH-$DOCKER_GEN_VERSION.tar.gz /tmp/
 ADD https://raw.githubusercontent.com/diafygi/acme-tiny/$ACME_TINY_VERSION/acme_tiny.py /bin/acme_tiny
 
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / &&\
-    tar -C /bin -xzf /tmp/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz && \
-    rm /tmp/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz && \
-    rm /tmp/s6-overlay-amd64.tar.gz && \
+RUN tar xzf /tmp/s6-overlay-$ARCH.tar.gz -C / &&\
+    tar -C /bin -xzf /tmp/docker-gen-linux-${ARCH}-$DOCKER_GEN_VERSION.tar.gz && \
+    rm /tmp/docker-gen-linux-$ARCH-$DOCKER_GEN_VERSION.tar.gz && \
+    rm /tmp/s6-overlay-$ARCH.tar.gz && \
     rm /etc/nginx/conf.d/default.conf && \
     apt-get update && \
     apt-get install -y python ruby cron iproute2 apache2-utils && \

--- a/Readme.armhf
+++ b/Readme.armhf
@@ -1,0 +1,5 @@
+#to build armhf image from amd64 machine:
+#Install qemu, see https://github.com/multiarch/qemu-user-static
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#Pass relevant args to the docker build cmd
+docker build  --build-arg DIST=arm32v7/nginx:1.17.3 --build-arg ARCH=armhf -t https-portal:armhf-master .


### PR DESCRIPTION
I propose this PR to allow cross build of armhf image on amd64 platform.
I also provide Readme.armhf with short instructions.

This Dockerfile will need args to be passed to build the armhf image (DIST and ARCH). If no args are passed, the Dockerfile shall behave as before the PR (aka build the image for amd64)
