### PR TITLE
Added built-in log rotation for Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ ARG  DIST=nginx:1.17.3
 FROM $DIST
 ARG  ARCH=amd64
 
+# Delete sym links from nginx image, install logrotate
+RUN rm /var/log/nginx/access.log && \
+    rm /var/log/nginx/error.log && \
+    apt-get update && \
+    apt-get -y install logrotate
+
 WORKDIR /root
 
 ENV S6_OVERLAY_VERSION v1.22.1.0
@@ -27,5 +33,6 @@ COPY ./fs_overlay /
 RUN chmod a+x /bin/*
 
 VOLUME /var/lib/https-portal
+VOLUME /var/log/nginx
 
 ENTRYPOINT ["/init"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Docker Hub page:
     - [Share Certificates with Other Apps](#share-certificates-with-other-apps)
     - [HTTP Basic Auth](#http-basic-auth)
     - [Access Restriction](#access-restriction)
+    - [Logging configuration](#logging-configuration)
     - [Debugging](#debugging)
   - [Advanced Usage](#advanced-usage)
     - [Configure Nginx through Environment Variables](#configure-nginx-through-environment-variables)
@@ -374,6 +375,55 @@ my_app:
 ```
 
 For valid IP values see [Nginx allow](http://nginx.org/en/docs/http/ngx_http_access_module.html#allow)
+
+### Logging configuration
+
+By default no Nginx logs are written. There are few options to set them up:
+
+* Redirect error/access logs to stdout/stderr:
+  
+  ```yaml
+  https-portal:
+    # ...
+    environment:
+      ERROR_LOG: stdout
+      ACCESS_LOG: stderr
+  ```
+
+* Write logs to default locations:
+
+  ```yaml
+  https-portal:
+    # ...
+    environment:
+      ERROR_LOG: default
+      ACCESS_LOG: default
+    volumes:
+      - /path/to/log/directory:/var/log/nginx/
+      - /path/to/logrotate/state/directory:/var/lib/logrotate/
+  ```
+
+  Default log files pathes are `/var/log/nginx/access.log` and `/var/log/nginx/error.log`.
+
+  Log files within default location `/var/log/nginx/*.log` are rotated on daily basis.
+  HTTPS-PORTAL will keep up to 30 log files and will compress files older than 2 days
+  (so current day log and previous day log are both available in plain text while all older ones are compresses).
+
+  If you want to alter log rotation configuration, you can overwrite `/etc/logrotate.d/nginx`.
+
+* Write logs to custom locations:
+
+  ```yaml
+  https-portal:
+    # ...
+    environment:
+      ERROR_LOG: /var/log/custom-logs/error.log
+      ACCESS_LOG: /var/log/custom-logs/access.log
+    volumes:
+      - /path/to/log/directory:/var/log/custom-logs/
+  ```
+
+  Note that no automatic log rotation will be performed in this case.
 
 ### Debugging
 

--- a/fs_overlay/etc/crontab
+++ b/fs_overlay/etc/crontab
@@ -9,3 +9,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user  command
 42 7 * * * root  . /etc/cron_env.sh; /bin/renew_certs > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+45 3 * * * root  . /etc/cron_env.sh; /usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.d/nginx -l /var/log/nginx/logrotate.log

--- a/fs_overlay/etc/logrotate.d/nginx
+++ b/fs_overlay/etc/logrotate.d/nginx
@@ -1,0 +1,20 @@
+/var/log/nginx/*.log {
+    daily
+    missingok
+    rotate 30
+    dateext
+    olddir /var/log/nginx
+    compress
+    delaycompress
+    notifempty
+    create 0640 nginx nginx
+    sharedscripts
+    prerotate
+        if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+            run-parts /etc/logrotate.d/httpd-prerotate; \
+        fi \
+    endscript
+    postrotate
+        invoke-rc.d nginx rotate >/dev/null 2>&1
+    endscript
+}

--- a/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
@@ -24,8 +24,6 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
     <% end %>
 
-    access_log <%= ENV['ACCESS_LOG'] || "off" %>;
-
     <% if ENV['WEBSOCKET'] && ENV['WEBSOCKET'].downcase == 'true' %>
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -33,7 +31,33 @@ http {
     }
     <% end %>
 
-    access_log  /var/log/nginx/access.log  main;
+    <% if ENV['ACCESS_LOG'] == 'off' || ENV['ACCESS_LOG'] == '' %>
+    access_log off;
+    <% elsif ENV['ACCESS_LOG'] == 'stdout' %>
+    access_log /dev/stdout main buffer=<%= ENV['ACCESS_LOG_BUFFER'] || "16k" %>;
+    <% else %>
+    <% elsif ENV['ACCESS_LOG'] == 'stderr' %>
+    access_log /dev/stderr main buffer=<%= ENV['ACCESS_LOG_BUFFER'] || "16k" %>;
+    <% else %>
+    <% elsif ENV['ACCESS_LOG'] == 'default' %>
+    access_log /var/log/nginx/access.log main buffer=<%= ENV['ACCESS_LOG_BUFFER'] || "16k" %>;
+    <% else %>
+    access_log <%= ENV['ACCESS_LOG'] %>  main buffer=<%= ENV['ACCESS_LOG_BUFFER'] || "16k" %>;
+    <% end %>
+
+    <% if ENV['ERROR_LOG'] == 'off' || ENV['ERROR_LOG'] == '' %>
+    error_log off;
+    <% elsif ENV['ERROR_LOG'] == 'stdout' %>
+    error_log /dev/stdout <%= ENV['ERROR_LOG_LEVEL'] || "error" %>;
+    <% else %>
+    <% elsif ENV['ERROR_LOG'] == 'stderr' %>
+    error_log /dev/stderr <%= ENV['ERROR_LOG_LEVEL'] || "error" %>;
+    <% else %>
+    <% elsif ENV['ERROR_LOG'] == 'default' %>
+    error_log /var/log/nginx/error.log <%= ENV['ERROR_LOG_LEVEL'] || "error" %>;
+    <% else %>
+    error_log <%= ENV['ERROR_LOG'] || "/var/log/nginx/error.log" %> <%= ENV['ERROR_LOG_LEVEL'] || "error" %>;
+    <% end %>
 
     sendfile        on;
 


### PR DESCRIPTION
Added built-in Nginx log rotation and log configuration:

* Default behaviour is not changed
* Added a shortcut to redirect Nginx logs to stderr/stdout
* Added a shortcut to redirect Nginx logs to default location (`/var/log/nginx/access.log` and `/var/log/nginx/error.log`
* Added a pre-configured logrotate tool targeted to rotate `/var/log/nginx/*.log` files on daily basis.
* Added configuration variables to change error log level and access log buffering.

See #231 for discussion.
