### PR TITLE
Fixed #233 - websocket proxying was affecting POST requests

### DIFF
--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -54,7 +54,7 @@ server {
         <% if ENV['WEBSOCKET'] && ENV['WEBSOCKET'].downcase == 'true' %>
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_read_timeout 2h;
         <% end %>
     }


### PR DESCRIPTION
Fixed issue #233  

Variable `$connection_upgrade` is already mapped [here](https://github.com/SteveLTN/https-portal/blob/master/fs_overlay/var/lib/nginx-conf/nginx.conf.erb#L30) so there was no need to map it.