### PR TITLE
Fix cron_env.sh permission to run cron auto renew properly

### DIFF
--- a/fs_overlay/etc/cont-init.d/10-persist-env
+++ b/fs_overlay/etc/cont-init.d/10-persist-env
@@ -3,3 +3,4 @@
 # Persist envs for cron jobs to use
 
 printenv | sed '/^[[:space:]]*$/d' | sed 's/^\(.*\)$/export "\1"/g' > /etc/cron_env.sh
+chmod +x /etc/cron_env.sh


### PR DESCRIPTION
I'm noticed that cron auto renew is not working and my certificates going to be expiring.
I digged and found that `/etc/cron_env.sh` file has no execution bit, and cron auto renew seems failling due to lack of environment valiables (I'm not 100% sure because there is no logs related this).

```
root@573f81c86dba:/# /etc/cron_env.sh
bash: /etc/cron_env.sh: Permission denied

root@573f81c86dba:/# ls -alh /etc/cron_env.sh
-rw-r--r-- 1 root root 745 Aug 24 16:51 /etc/cron_env.sh
```

This patch fix `/etc/cron_env.sh` file permission by adding execution bit.