### PR TITLE
Allow per-domain config blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,12 +551,15 @@ You can also make it multi-line:
 
 The `CUSTOM_NGINX_SERVER_CONFIG_BLOCK` will be inserted after all other configuration blocks listed in section "Configure Nginx through Environment Variables", and it might conflict with other configurations.
 
+In addition to the global `CUSTOM_NGINX_SERVER_CONFIG_BLOCK`, which applies to all configurations, there are `CUSTOM_NGINX_<UPPERCASE_AND_UNDERSCORED_DOMAIN_NAME>_CONFIG_BLOCK`s, which are inserted after the `CUSTOM_NGINX_SERVER_CONFIG_BLOCK`, but only into the configuration file for a specific site. To make specific changes to `example.com` only, create an environment variable `CUSTOM_NGINX_EXAMPLE_COM_CONFIG_BLOCK`.
+
 ```
 # generated Nginx config:
 server {
 	listen 443 ssl http2;
 	... # (other configurations)
 	<%= CUSTOM_NGINX_SERVER_CONFIG_BLOCK %>
+	<%= CUSTOM_NGINX_<DOMAIN_NAME>_CONFIG_BLOCK %>
 	location / {
 		...
 	}

--- a/fs_overlay/opt/certs_manager/models/domain.rb
+++ b/fs_overlay/opt/certs_manager/models/domain.rb
@@ -73,6 +73,10 @@ class Domain
     parsed_descriptor[:domain]
   end
 
+  def env_name
+    name.upcase.tr('^A-Z0-9', '_')
+  end
+
   def upstream_backend_name
     "backend_" + parsed_descriptor[:domain]
   end

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -50,6 +50,10 @@ server {
         <%= ENV['CUSTOM_NGINX_SERVER_CONFIG_BLOCK'] %>
     <% end %>
 
+    <% if ENV["CUSTOM_NGINX_#{domain.env_name}_CONFIG_BLOCK"] %>
+        <%= ENV["CUSTOM_NGINX_#{domain.env_name}_CONFIG_BLOCK"] %>
+    <% end %>
+
     <% if domain.upstream %>
     location / {
         <% if ENV['DYNAMIC_UPSTREAM'] && ENV['DYNAMIC_UPSTREAM'].downcase == 'true' %>

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -7,34 +7,35 @@ RSpec.describe Domain do
     allow(FileUtils).to receive(:mkdir_p)
   end
 
-  it 'returns correct name, upstream. redirect_target_url and stage' do
-    keys = [:descriptor, :name, :upstream_proto, :upstreams, :redirect_target_url, :stage, :basic_auth_username, :basic_auth_password, :access_restriction]
+  it 'returns correct names, upstream. redirect_target_url, stage etc.' do
+    keys = [:descriptor, :name, :env_name, :upstream_proto, :upstreams, :redirect_target_url, :stage, :basic_auth_username, :basic_auth_password, :access_restriction]
 
     domain_configs = [
-      ['example.com', 'example.com', nil, [], nil, 'local', nil, nil, nil],
-      [' example.com ', 'example.com', nil, [], nil, 'local', nil, nil, nil],
-      ['example.com #staging', 'example.com', nil, [], nil, 'staging', nil, nil, nil],
-      ['example.com -> http://target ', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'local', nil, nil, nil],
-      ["example.com \n-> http://target \n", 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'local', nil, nil, nil],
-      ["example.com\n-> http://target ", 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'local', nil, nil, nil],
-      ['example.com -> http://target:8000', 'example.com', 'http://', [{:address => 'target:8000', :parameters => nil}], nil, 'local', nil, nil, nil],
-      ['example.com -> target:8000', 'example.com', 'http://', [{:address => 'target:8000', :parameters => nil}], nil, 'local', nil, nil, nil],
-      ['example.com => http://target', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], 'http://target', 'local', nil, nil, nil],
-      ['example.com => https://target', 'example.com', 'https://', [{:address => 'target', :parameters => nil}], 'https://target', 'local', nil, nil, nil],
-      ['example.com => target', 'example.com', 'https://', [{:address => 'target', :parameters => nil}], 'https://target', 'local', nil, nil, nil],
-      ['example.com=>http://target', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], 'http://target', 'local', nil, nil, nil],
-      ['example.com -> http://target #staging', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', nil, nil, nil],
-      ['example.com => http://target #staging', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], 'http://target', 'staging', nil, nil, nil],
-      ['example.com->http://target #staging', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', nil, nil, nil],
-      ['exam-ple.com->http://tar-get #staging', 'exam-ple.com', 'http://', [{:address => 'tar-get', :parameters => nil}], nil, 'staging', nil, nil, nil],
-      ['example_.com->http://target #staging', 'example_.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', nil, nil, nil],
-      ['example.com->http://tar_get_ #staging', 'example.com', 'http://', [{:address => 'tar_get_', :parameters => nil}], nil, 'staging', nil, nil, nil],
-      ['username:password@example.com', 'example.com', nil, [], nil, 'local', 'username', 'password', nil],
-      ['username:password@example.com -> http://target #staging', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', 'username', 'password', nil],
-      ['[1.2.3.4/24]username:password@example.com -> http://target #staging', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', 'username', 'password', %w(1.2.3.4/24)],
-      [' [ 1.2.3.4 4.3.2.1/24 ] username:password@example.com -> http://target #staging', 'example.com', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', 'username', 'password', %w(1.2.3.4 4.3.2.1/24)],
-      ['example.com -> https://target1|target2:8000', 'example.com', 'https://', [{:address => 'target1', :parameters => nil}, {:address => 'target2:8000', :parameters => nil}], nil, 'local', nil, nil, nil],
-      ['example.com -> http://target1:8000|target2:8001[backup max_conns=100]', 'example.com', 'http://', [{:address => 'target1:8000', :parameters => nil}, {:address => 'target2:8001', :parameters => 'backup max_conns=100'}], nil, 'local', nil, nil, nil],
+      ['example.com', 'example.com', 'EXAMPLE_COM', nil, [], nil, 'local', nil, nil, nil],
+      ['4example.com', '4example.com', '4EXAMPLE_COM', nil, [], nil, 'local', nil, nil, nil],
+      [' example.com ', 'example.com', 'EXAMPLE_COM', nil, [], nil, 'local', nil, nil, nil],
+      ['example.com #staging', 'example.com', 'EXAMPLE_COM', nil, [], nil, 'staging', nil, nil, nil],
+      ['example.com -> http://target ', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'local', nil, nil, nil],
+      ["example.com \n-> http://target \n", 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'local', nil, nil, nil],
+      ["example.com\n-> http://target ", 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'local', nil, nil, nil],
+      ['example.com -> http://target:8000', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target:8000', :parameters => nil}], nil, 'local', nil, nil, nil],
+      ['example.com -> target:8000', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target:8000', :parameters => nil}], nil, 'local', nil, nil, nil],
+      ['example.com => http://target', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], 'http://target', 'local', nil, nil, nil],
+      ['example.com => https://target', 'example.com', 'EXAMPLE_COM', 'https://', [{:address => 'target', :parameters => nil}], 'https://target', 'local', nil, nil, nil],
+      ['example.com => target', 'example.com', 'EXAMPLE_COM', 'https://', [{:address => 'target', :parameters => nil}], 'https://target', 'local', nil, nil, nil],
+      ['example.com=>http://target', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], 'http://target', 'local', nil, nil, nil],
+      ['example.com -> http://target #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', nil, nil, nil],
+      ['example.com => http://target #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], 'http://target', 'staging', nil, nil, nil],
+      ['example.com->http://target #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', nil, nil, nil],
+      ['exam-ple.com->http://tar-get #staging', 'exam-ple.com', 'EXAM_PLE_COM', 'http://', [{:address => 'tar-get', :parameters => nil}], nil, 'staging', nil, nil, nil],
+      ['example_.com->http://target #staging', 'example_.com', 'EXAMPLE__COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', nil, nil, nil],
+      ['example.com->http://tar_get_ #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'tar_get_', :parameters => nil}], nil, 'staging', nil, nil, nil],
+      ['username:password@example.com', 'example.com', 'EXAMPLE_COM', nil, [], nil, 'local', 'username', 'password', nil],
+      ['username:password@example.com -> http://target #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', 'username', 'password', nil],
+      ['[1.2.3.4/24]username:password@example.com -> http://target #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', 'username', 'password', %w(1.2.3.4/24)],
+      [' [ 1.2.3.4 4.3.2.1/24 ] username:password@example.com -> http://target #staging', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target', :parameters => nil}], nil, 'staging', 'username', 'password', %w(1.2.3.4 4.3.2.1/24)],
+      ['example.com -> https://target1|target2:8000', 'example.com', 'EXAMPLE_COM', 'https://', [{:address => 'target1', :parameters => nil}, {:address => 'target2:8000', :parameters => nil}], nil, 'local', nil, nil, nil],
+      ['example.com -> http://target1:8000|target2:8001[backup max_conns=100]', 'example.com', 'EXAMPLE_COM', 'http://', [{:address => 'target1:8000', :parameters => nil}, {:address => 'target2:8001', :parameters => 'backup max_conns=100'}], nil, 'local', nil, nil, nil],
     ]
 
     domain_configs.map { |config|
@@ -43,6 +44,7 @@ RSpec.describe Domain do
       domain = Domain.new(config[:descriptor])
 
       expect(domain.name).to eq(config[:name]), lambda { "Parsing failed on #{config[:descriptor].inspect} method :name, expected #{config[:name].inspect}, got #{domain.name.inspect}" }
+      expect(domain.env_name).to eq(config[:env_name]), lambda { "Parsing failed on #{config[:descriptor].inspect} method :env_name, expected #{config[:env_name].inspect}, got #{domain.env_name.inspect}" }
       expect(domain.upstream_proto).to eq(config[:upstream_proto]), lambda { "Parsing failed on #{config[:descriptor].inspect} method :upstream_proto, expected #{config[:upstream_proto].inspect}, got #{domain.upstream_proto.inspect}" }
       expect(domain.upstreams).to eq(config[:upstreams]), lambda { "Parsing failed on #{config[:descriptor].inspect} method :upstreams, expected #{config[:upstreams].inspect}, got #{domain.upstreams.inspect}" }
       expect(domain.redirect_target_url).to eq(config[:redirect_target_url]), lambda { "Parsing failed on #{config[:descriptor].inspect} method :redirect_target_url, expected #{config[:redirect_target_url].inspect}, got #{domain.redirect_target_url.inspect}" }


### PR DESCRIPTION
Some configurations require different redirects or proxy settings for different locations. If the portal only handles a single domain/backend, this is usually no problem and can be handled with a `CUSTOM_NGINX_SERVER_CONFIG_BLOCK`. However, with multiple domains (the case where https-portal really excels), things get tricky.

Redirects can be handled with `if` constructs, which are [https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/](evil, inefficient, and buggy).

A notable case for complicated proxy settings is [Collabora Online](https://www.collaboraoffice.com/code/nginx-reverse-proxy/).

This extends the `CUSTOM_NGINX_SERVER_CONFIG_BLOCK` concept to per-domain config blocks. The contents of `CUSTOM_NGINX_EXAMPLE_COM_CONFIG_BLOCK` will be inserted just after the `CUSTOM_NGINX_SERVER_CONFIG_BLOCK`, but only in the configuration file for `example.com`.