### PR TITLE
Evenly distribute certificate renewal time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN sh -c "wget -q https://github.com/jwilder/docker-gen/releases/download/$DOCK
     tar xzC /bin
 RUN wget -q https://raw.githubusercontent.com/diafygi/acme-tiny/$ACME_TINY_VERSION/acme_tiny.py -O /bin/acme_tiny
 
-RUN rm /etc/nginx/conf.d/default.conf
+RUN rm /etc/nginx/conf.d/default.conf /etc/crontab
 
 COPY ./fs_overlay /
 

--- a/fs_overlay/opt/certs_manager/certs_manager.rb
+++ b/fs_overlay/opt/certs_manager/certs_manager.rb
@@ -8,6 +8,8 @@ class CertsManager
 
   def setup
     add_dockerhost_to_hosts
+    ensure_crontab
+
     NAConfig.domains.each do |domain|
       if NAConfig.debug_mode?
         domain.print_debug_info
@@ -87,5 +89,19 @@ class CertsManager
       lock.flock File::LOCK_EX
       yield(block)
     end
+  end
+
+  def ensure_crontab
+    crontab = '/etc/crontab'
+
+    unless File.exist?(crontab)
+      File.open(crontab, 'w') do |file|
+        file.write compiled_crontab
+      end
+    end
+  end
+
+  def compiled_crontab
+    ERBBinding.new('/var/lib/crontab.erb', {}).compile
   end
 end

--- a/fs_overlay/var/lib/crontab.erb
+++ b/fs_overlay/var/lib/crontab.erb
@@ -1,3 +1,8 @@
+# THIS FILE IS AUTO-GENERATED FROM /var/lib/crontab.erb ON FIRST RUN.
+# Certificate renewal is set to start at a random fractional second evenly
+# throughout the day on container creation, to avoid Let's Encrypt workload
+# peaks.
+#
 # /etc/crontab: system-wide crontab
 # Unlike any other crontab you don't have to run the `crontab'
 # command to install the new version when you edit this file
@@ -8,5 +13,5 @@ SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user  command
-42 7 * * * root  . /etc/cron_env.sh; /bin/renew_certs > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+<%= rand 60 %> <%= rand 24 %> * * * root  . /etc/cron_env.sh; /bin/sleep <%= rand * 60 %>; /bin/renew_certs > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
 45 3 * * * root  . /etc/cron_env.sh; /usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.d/nginx -l /var/log/nginx/logrotate.log


### PR DESCRIPTION
This resolves #255.

I modeled the code after `ensure_welcome_page`, including using two functions. After adaptation, it were only a few lines of code remaining, which I preferred not to create a new file for. (And there also was not a good place to add it to, either.)

The original `crontab` needs to be deleted as part of the container creation, as the system-default cron will otherwise prevail. I still think the `ensure_…` way is better than recreating it on every launch.

Furthermore, I added the `sleep` directly into the `crontab` instead of the Ruby code. (The sub-second precision is excessive, but keeps the code simpler, IMHO)

Let me know if you would have taken different decisions.