### PR TITLE
Get rid of 4095 byte limit per environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 # Need this already now, but cannot copy remainder of fs_overlay yet
 COPY ./fs_overlay/bin/archname /bin/
 
-ENV S6_OVERLAY_VERSION v1.22.1.0
+ENV S6_OVERLAY_VERSION v2.2.0.1
 ENV DOCKER_GEN_VERSION 0.7.4
 ENV ACME_TINY_VERSION 4.1.0
 


### PR DESCRIPTION
Only the first 4095 of `DOMAINS` (or any other environment variable) will be used, truncating the rest, causing weird problems.

After double-checking all the ruby code that it that nothing limited the length of `ENV['DOMAINS']` and successfully running the ruby code from within `docker exec`, I tracked this down to `with-contenv` from `s6-overlay`, thanks to the cronjob just firing while I was looking for the reasons. So it was clear that `/etc/cron_env.sh` was the culprit.

`with-contenv` only copyies the first 4095 bytes of an environment variable (see also [`s6-overlay` Changelog](https://github.com/just-containers/s6-overlay/blob/master/CHANGELOG.md#version-2000) and [`justc-envdir` README](https://github.com/just-containers/justc-envdir#justc-envdir)).

The fix is easy: Just upgrade to `s6-overlay` of at least `2.0.0.0`. It seems to be running fine on two machines for me (one of them being the one with the long list of `DOMAINS`).

BTW1: As executing `/bin/bash` from the `docker exec` yields the right environment, is the environment reading process really necessary?

BTW2: Maybe it is worthwhile to look at upgrading the other dependencies.