### PR TITLE
Use s6-overlay mechanisms for cron environment

### DIFF
--- a/fs_overlay/etc/cont-init.d/10-persist-env
+++ b/fs_overlay/etc/cont-init.d/10-persist-env
@@ -1,5 +1,0 @@
-#!/usr/bin/with-contenv sh
-
-# Persist envs for cron jobs to use
-
-export > /etc/cron_env.sh

--- a/fs_overlay/var/lib/crontab.erb
+++ b/fs_overlay/var/lib/crontab.erb
@@ -13,5 +13,5 @@ SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user  command
-<%= rand 60 %> <%= rand 24 %> * * * root  . /etc/cron_env.sh; /bin/sleep <%= rand * 60 %>; /bin/renew_certs > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-45 3 * * * root  . /etc/cron_env.sh; /usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.d/nginx -l /var/log/nginx/logrotate.log
+<%= rand 60 %> <%= rand 24 %> * * * root  /bin/sleep <%= '%.3f' % (rand * 60) %>; /usr/bin/with-contenv /bin/renew_certs > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+45 3 * * * root  /usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.d/nginx -l /var/log/nginx/logrotate.log


### PR DESCRIPTION
While trying to understand the `s6-overlay` and `https-portal` workings more in depth for #261, I noticed that `s6-overlay` provides `with-contenv`. Using that obviates the need for maintaining the environment in `/etc/cron_env.sh` a second time. This PR makes things more `s6-overlay`-ish (and simplifies operation). This addresses question 1 from #260.

- `logrotate` and its children do not require the environment
- `with-contenv` loads the container environment for `/bin/renew`
  - Could also be done in the `#!` line of `renew`, but keeping it here reminds
    other cron users of the non-automatic environment
  - Unrelated: Also limit excessive sleep precision to milliseconds

(When reading the [`s6-overlay` documentation](https://github.com/just-containers/s6-overlay#customizing-s6-behaviour), I got the impression that just setting `S6_KEEP_ENV` globally (i.e., from the Dockerfile) would make the Dockerfile environment available to all processes. However, this does not seem to be the case, it just suppressed reloading the environment in child `with-contenv`-based processes.)