### PR TITLE
Allow on-the-fly reconfiguration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm /var/log/nginx/access.log && \
 WORKDIR /root
 
 RUN apt-get update && \
-    apt-get install -y python ruby cron iproute2 apache2-utils logrotate wget && \
+    apt-get install -y python ruby cron iproute2 apache2-utils logrotate wget inotify-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Docker Hub page:
     - [Other configurations](#other-configurations)
   - [Advanced Usage](#advanced-usage)
     - [Configure Nginx through Environment Variables](#configure-nginx-through-environment-variables)
+    - [Change Configuration Dynamically](#change-configuration-dynamically)
     - [Override Nginx Configuration Files](#override-nginx-configuration-files)
   - [How It Works](#how-it-works)
   - [About Rate Limits of Let's Encrypt](#about-rate-limits-of-lets-encrypt)
@@ -572,6 +573,14 @@ server {
 	}
 }
 ```
+
+### Change Configuration Dynamically
+
+Environment variables may be dynamically overridden by modifying files
+`/var/lib/https-portal/dynamic-env`. The file's name and contents will create
+an environment variable with that name and contents, respectively. About 1s
+after the last modification, the configuration will be updated to reflect the
+new configuration. This allows modifying the configuration without downtime.
 
 ### Override Nginx Configuration Files
 

--- a/fs_overlay/bin/setup
+++ b/fs_overlay/bin/setup
@@ -1,0 +1,4 @@
+#!/usr/bin/ruby
+require '/opt/certs_manager/certs_manager'
+
+CertsManager.new.setup

--- a/fs_overlay/etc/cont-init.d/20-setup
+++ b/fs_overlay/etc/cont-init.d/20-setup
@@ -1,4 +1,2 @@
-#!/usr/bin/with-contenv ruby
-require '/opt/certs_manager/certs_manager'
-
-CertsManager.new.setup
+#!/usr/bin/with-contenv /usr/bin/execlineb
+/usr/bin/justc-envdir -I /var/lib/https-portal/dynamic-env /bin/setup

--- a/fs_overlay/etc/services.d/10-docker-gen/run
+++ b/fs_overlay/etc/services.d/10-docker-gen/run
@@ -1,3 +1,5 @@
 #!/usr/bin/with-contenv sh
 
-docker-gen -watch -only-exposed -notify-output -notify reconfig /etc/docker-gen/domains.tmpl /var/run/domains
+docker-gen -watch -only-exposed -notify-output -notify \
+	"justc-envdir -I /var/lib/https-portal/dynamic-env /bin/reconfig" \
+	/etc/docker-gen/domains.tmpl /var/run/domains

--- a/fs_overlay/etc/services.d/30-dynamic-env/finish
+++ b/fs_overlay/etc/services.d/30-dynamic-env/finish
@@ -1,0 +1,3 @@
+#!/usr/bin/execlineb -S0
+
+s6-svscanctl -t /var/run/s6/services

--- a/fs_overlay/etc/services.d/30-dynamic-env/run
+++ b/fs_overlay/etc/services.d/30-dynamic-env/run
@@ -1,0 +1,37 @@
+#!/bin/sh
+dir=/var/lib/https-portal/dynamic-env
+mkdir -p $dir
+
+# Remember when we started (tiny race condition window)
+touch $dir.stamp # Outside of watched dir!
+
+# Wait for a modification to an all-uppercase file (ignore temp/swp files)
+inotifywait -qm -e close_write,move,delete $dir | while read line
+do
+	if echo "$line" | grep -q ' [_A-Z]*$'
+	then
+		echo "[dynamic-env] All-uppercase file modified in $dir" >&2
+
+		echo -n "[dynamic-env] Wait for activity to cease..." >&2
+		while inotifywait -qq -t 1 -e close_write,move,delete $dir
+		do
+			echo -n . >&2
+		done
+		echo " -- ceased" >&2
+
+		# Apply new configuration; but only, if anything actually
+		# changed (top-level "while" loop will continue getting
+		# potentially old events)
+		if find $dir -newer $dir.stamp | grep -q .
+		then
+			# Remember when we started (tiny race condition window)
+			touch $dir.stamp # Outside of watched dir!
+
+			echo "[dynamic-env] File changed since last run: Applying new configuration..." >&2
+			/usr/bin/justc-envdir $dir /bin/reconfig
+			echo "[dynamic-env] Configuration applied" >&2
+		else
+			echo "[dynamic-env] No file changed since last run -- suppressing" >&2
+		fi
+	fi
+done

--- a/fs_overlay/etc/services.d/30-dynamic-env/run
+++ b/fs_overlay/etc/services.d/30-dynamic-env/run
@@ -10,14 +10,13 @@ inotifywait -qm -e close_write,move,delete $dir | while read line
 do
 	if echo "$line" | grep -q ' [_A-Z]*$'
 	then
-		echo "[dynamic-env] All-uppercase file modified in $dir" >&2
+		echo "[dynamic-env] All-uppercase file modified in $dir"
 
-		echo -n "[dynamic-env] Wait for activity to cease..." >&2
+		echo "[dynamic-env] Wait for activity to cease..."
 		while inotifywait -qq -t 1 -e close_write,move,delete $dir
 		do
-			echo -n . >&2
+			:
 		done
-		echo " -- ceased" >&2
 
 		# Apply new configuration; but only, if anything actually
 		# changed (top-level "while" loop will continue getting
@@ -27,11 +26,11 @@ do
 			# Remember when we started (tiny race condition window)
 			touch $dir.stamp # Outside of watched dir!
 
-			echo "[dynamic-env] File changed since last run: Applying new configuration..." >&2
+			echo "[dynamic-env] File changed since last run: Applying new configuration..."
 			/usr/bin/justc-envdir $dir /bin/reconfig
 			echo "[dynamic-env] Configuration applied" >&2
 		else
-			echo "[dynamic-env] No file changed since last run -- suppressing" >&2
+			echo "[dynamic-env] No file changed since last run -- suppressing"
 		fi
 	fi
 done

--- a/fs_overlay/etc/services.d/30-dynamic-env/run
+++ b/fs_overlay/etc/services.d/30-dynamic-env/run
@@ -1,19 +1,21 @@
 #!/bin/sh
-dir=/var/lib/https-portal/dynamic-env
-mkdir -p $dir
+env=/var/lib/https-portal/dynamic-env
+dom=/var/lib/https-portal/dynamic-domains
+mkdir -p $env $dom
 
 # Remember when we started (tiny race condition window)
-touch $dir.stamp # Outside of watched dir!
+touch $env.stamp # Outside of watched dirs!
 
 # Wait for a modification to an all-uppercase file (ignore temp/swp files)
-inotifywait -qm -e close_write,move,delete $dir | while read line
+inotifywait -qm -e close_write,move,delete $env $dom | while read line
 do
-	if echo "$line" | grep -q ' [_A-Z]*$'
+	echo "[dynamic-env] read $line"
+	if echo "$line" | egrep -q '( [_A-Z]*|\.dom)$'
 	then
-		echo "[dynamic-env] All-uppercase file modified in $dir"
+		echo "[dynamic-env] All-uppercase or .dom file modified"
 
 		echo "[dynamic-env] Wait for activity to cease..."
-		while inotifywait -qq -t 1 -e close_write,move,delete $dir
+		while inotifywait -qq -t 1 -e close_write,move,delete $env $dom
 		do
 			:
 		done
@@ -21,13 +23,13 @@ do
 		# Apply new configuration; but only, if anything actually
 		# changed (top-level "while" loop will continue getting
 		# potentially old events)
-		if find $dir -newer $dir.stamp | grep -q .
+		if find $env $dom -newer $env.stamp | grep -q .
 		then
 			# Remember when we started (tiny race condition window)
-			touch $dir.stamp # Outside of watched dir!
+			touch $env.stamp # Outside of watched dirs!
 
 			echo "[dynamic-env] File changed since last run: Applying new configuration..."
-			/usr/bin/justc-envdir $dir /bin/reconfig
+			/usr/bin/justc-envdir $env /bin/reconfig
 			echo "[dynamic-env] Configuration applied" >&2
 		else
 			echo "[dynamic-env] No file changed since last run -- suppressing"

--- a/fs_overlay/opt/certs_manager/lib/commands.rb
+++ b/fs_overlay/opt/certs_manager/lib/commands.rb
@@ -13,11 +13,13 @@ module Commands
     system "mkdir -p #{domain.dir}"
   end
 
-  def add_dockerhost_to_hosts
-    docker_host_ip = `/sbin/ip route|awk '/default/ { print $3 }'`.strip
+  def ensure_dockerhost_in_hosts
+    unless File.foreach("/etc/hosts").grep(/dockerhost/).any?
+      docker_host_ip = `/sbin/ip route|awk '/default/ { print $3 }'`.strip
 
-    File.open('/etc/hosts', 'a') do |f|
-      f.puts "#{docker_host_ip}\tdockerhost"
+      File.open('/etc/hosts', 'a') do |f|
+        f.puts "#{docker_host_ip}\tdockerhost"
+      end
     end
   end
 

--- a/fs_overlay/opt/certs_manager/lib/na_config.rb
+++ b/fs_overlay/opt/certs_manager/lib/na_config.rb
@@ -40,11 +40,11 @@ module NAConfig
   end
 
   def self.auto_discovered_domains
-    if File.exist? '/var/run/domains'
-      parse File.read('/var/run/domains')
-    else
-      []
+    doms = []
+    Dir['/var/run/domains', "#{NAConfig.portal_base_dir}/dynamic-domains/*.dom"].each do |file|
+      doms.concat(parse File.read(file))
     end
+    doms
   end
 
   def self.debug_mode?


### PR DESCRIPTION
Reducing down-time even further using live reconfiguration. `reconfig` now essentially does the same thing as `setup`, but without stopping/starting nginx, just reloading it.

Also, domains can now be removed and will also disappear (the certificates will remain as a cache).

Files placed in `/var/lib/https-portal/dynamic-env` override the environment
variables on the fly using `justc-envdir`. Changing these files will cause
an immediate reconfiguration, as if the container had been restarted, just
without downtime.