### PR TITLE
Need to import default environment

### DIFF
--- a/fs_overlay/etc/services.d/30-dynamic-env/run
+++ b/fs_overlay/etc/services.d/30-dynamic-env/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/with-contenv sh
 dir=/var/lib/https-portal/dynamic-env
 mkdir -p $dir
 


### PR DESCRIPTION
Otherwise, dynamic changes *only* use the dynamic environment,
not *in addition to* the default environment.

(Sorry, had too many branches related to `seamless-adding-domains`, resulting in the (wrong) conflict in #270 and accidentally closing it in a way I could not reopen it. So this replaces it.)