### PR TITLE
Only use temporary redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ PROXY_SEND_TIMEOUT=60;
 PROXY_READ_TIMEOUT=60;
 ACCESS_LOG=off;
 ACCESS_LOG_INCLUDE_HOST=off;            # include vhost in access log (useful for goaccess => use log-format=VCOMBINED)
+REDIRECT_CODE=307                       # Was 301 by default until 1.20.1
 ```
 
 #### Websocket

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -69,7 +69,7 @@ server {
     }
     <% elsif domain.redirect_target_url %>
     location / {
-      return    301 <%= domain.redirect_target_url %>$request_uri;
+        return    <%= ENV['REDIRECT_CODE'] || 307 %> <%= domain.redirect_target_url %>$request_uri;
     }
     <% else %>
     location / {


### PR DESCRIPTION
Not all redirects are meant to be permanent. Permanent redirects are cached for a long time in browsers (which bit me). So it is safer to keep them as temporary.

If there are good reasons to have a permanent redirect, it could be made configurable, e.g. by using a new arrow style (`~>`?).