### PR TITLE
Index file names configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ They correspond to the configuration options that you would normally put in `ngi
 The following are the available params with their default values:
 
 ```
+INDEX_FILES=index.html                  # A space-separated list of index file names to look for
 WORKER_PROCESSES=1
 WORKER_CONNECTIONS=1024
 KEEPALIVE_TIMEOUT=65

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -74,7 +74,7 @@ server {
     <% else %>
     location / {
         root   <%= domain.www_root %>;
-        index  index.html;
+        index  <%= ENV['INDEX_FILES'] || 'index.html' %>;
     }
     <% end %>
 }


### PR DESCRIPTION
When serving legacy static sites, they may use different conventions for naming the index file. For example, a site I serve uses `Welcome.html`. Making the index filename configurable helps here, in this case with `INDEX_FILES="index.html Welcome.html"`