### PR TITLE
Make Nginx configuration more modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,10 @@ server {
 }
 ```
 
+The variables `CUSTOM_NGINX_GLOBAL_HTTP_CONFIG_BLOCK` and `CUSTOM_NGINX_SERVER_PLAIN_CONFIG_BLOCK` can be used to add your own Nginx statements to the global `http` block or to the plaintext (non-SSL) `server` blocks.
+
+In the rare case that you want to change the handling of `/.well-known/acme-challenge/` requets, setting `ACME_CHALLENGE_BLOCK` will override the default configuration.
+
 ### Change Configuration Dynamically
 
 Environment variables may be dynamically overridden by modifying files

--- a/fs_overlay/opt/certs_manager/lib/nginx.rb
+++ b/fs_overlay/opt/certs_manager/lib/nginx.rb
@@ -87,7 +87,7 @@ module Nginx
   end
 
   def self.acme_challenge_location_snippet
-    <<-SNIPPET
+    ENV['ACME_CHALLENGE_BLOCK'] || <<-SNIPPET
       location /.well-known/acme-challenge/ {
           allow all;
           alias /var/www/default/challenges/;

--- a/fs_overlay/var/lib/nginx-conf/default.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.conf.erb
@@ -10,4 +10,9 @@ server {
     }
 
     <%= acme_challenge_location %>
+
+    <% if ENV['CUSTOM_NGINX_SERVER_PLAIN_CONFIG_BLOCK'] %>
+      <%= ENV['CUSTOM_NGINX_SERVER_PLAIN_CONFIG_BLOCK'] %>
+    <% end %>
+
 }

--- a/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/nginx.conf.erb
@@ -31,6 +31,9 @@ http {
     }
     <% end %>
 
+    <% if ENV['CUSTOM_NGINX_GLOBAL_HTTP_CONFIG_BLOCK'] %>
+        <%= ENV['CUSTOM_NGINX_GLOBAL_HTTP_CONFIG_BLOCK'] %>
+    <% end %>
     <% if !ENV['ACCESS_LOG'] || ENV['ACCESS_LOG'] == '' || ENV['ACCESS_LOG'] == 'off'  %>
     access_log off;
     <% elsif ENV['ACCESS_LOG'] == 'stdout' %>
@@ -115,14 +118,18 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
 
-    # Prevent Nginx from leaking other server configurations on the same machine
-    server {
-        listen      80 default_server;
-        server_name _;
-        return      444;
-    }
-    server {
-        listen      443 ssl default_server;
-        ssl_reject_handshake on;
-    }
+    <% if ENV['DEFAULT_SERVER_BLOCK'] %>
+      <%= ENV['DEFAULT_SERVER_BLOCK'] %>
+    <% else %>
+        # Prevent Nginx from leaking other server configurations on the same machine
+        server {
+            listen      80 default_server;
+            server_name _;
+            return      444;
+        }
+        server {
+            listen      443 ssl default_server;
+            ssl_reject_handshake on;
+        }
+    <% end %>
 }


### PR DESCRIPTION
Of course, It is possible to override the `*.erb` template files with your own template using `volume:` in `docker-compose.yml`. However, updates to the original templates inside the docker image will remain unnoticed, and will not be reflected, potentially causing problems as bug fixes (e.g. 0c35a4f4acfd99) or behavioral changes will not be reflected.

Making the configuration file more modular reduces the number of cases where the (brute-force) `volume:` file override method is required. It does not eliminate all problems that might occur through seemingly innocent changes in the docker template files, but many of them.

Anyone not using any of the new environment variables will not notice any difference, but the hooks are helpful if you have to fine-tune some behavior. For example, the `CUSTOM_NGINX_GLOBAL_HTTP_CONFIG_BLOCK` can be used to add a persistent proxy cache (`proxy_cache_path` only allowed at `http` level) or add additional `server` blocks which do not follow the normal rules (e.g., non-SSL server for a hostname, for which no SSL certificate can be obtained at all).

I use `CUSTOM_NGINX_SERVER_PLAIN_CONFIG_BLOCK` and `ACME_CHALLENGE_BLOCK` to handle failover scenarios which require modifying handling the ACME challenges.