### PR TITLE
Added variables escape example to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,14 @@ You can also make it multi-line:
     	add_header Strict-Transport-Security "max-age=60" always;
     	auth_basic "Password";	
 ```
+When using variables, you need to escape them with $:
+
+```yaml
+  environment:
+    ...
+    CUSTOM_NGINX_GLOBAL_HTTP_CONFIG_BLOCK: |
+        limit_req_zone $$binary_remote_addr zone=one:10m rate=1000r/m;
+```
 
 The `CUSTOM_NGINX_SERVER_CONFIG_BLOCK` will be inserted after all other configuration blocks listed in section "Configure Nginx through Environment Variables", and it might conflict with other configurations.
 


### PR DESCRIPTION
Using NGINX variables required escaping them, otherwise NGINX won't start with 
`nginx: [emerg] invalid number of arguments in "variable_name_here" directive in /etc/nginx/nginx.conf:31`.