### PR TITLE
Create self-signed certificate with CSR

### DIFF
--- a/fs_overlay/opt/certs_manager/lib/open_ssl.rb
+++ b/fs_overlay/opt/certs_manager/lib/open_ssl.rb
@@ -53,13 +53,11 @@ module OpenSSL
 
     command = <<-EOC
     openssl req -x509 \
-      -newkey rsa:#{NAConfig.key_length} \
-      -nodes \
+      -in #{domain.csr_path} \
+      -key #{domain.ongoing_key_path} \
       -out #{domain.ongoing_cert_path} \
-      -keyout #{domain.ongoing_key_path} \
       -days 90 \
       -batch \
-      -subj "/CN=#{domain.name}" \
       -addext "extendedKeyUsage = serverAuth"
     EOC
 


### PR DESCRIPTION
Current implementation ignores CSR when self-signing and force creates new RSA keypair, so
`CERTIFICATE_ALGORITHM=prime256v1` is not working for `STAGE=local`.

This PR fixes this by stop creating new RSA key on `self_sign` and
sign to CSR instead.