### PR TITLE
feat: add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,9 @@ RUN chmod a+x /bin/* && \
 VOLUME /var/lib/https-portal
 VOLUME /var/log/nginx
 
+
+# HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD wget -q -O /dev/null http://localhost:80/ || exit 1
+
+HEALTHCHECK --interval=5s --timeout=1s --start-period=2s --retries=20 CMD   service nginx status || exit 1
+
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
I added two strategies: one with wget commented , and the other based on systemd (service nginx).

Maybe the config for intervals, timeout, start-period and retries is not optimal for a wide range of cases, but it is fine in my case. 

Let me know if is interesting
