### PR TITLE
Enable HTTP/2 support regardless of IPv6 setting

### DIFF
--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -10,8 +10,9 @@ server {
     listen 443 ssl;
     <% if ENV['LISTEN_IPV6'] && ENV['LISTEN_IPV6'].downcase == 'true' %>
     listen [::]:443 ssl;
-    http2 on;
     <% end %>
+    http2 on;
+    
     server_name <%= domain.name %>;
 
     ssl_certificate <%= domain.chained_cert_path %>;


### PR DESCRIPTION
In the latest update 1.24.0 HTTP/2 support was incorrectly tied to the `LISTEN_IPV6` env-var. This PR fixes that so that HTTP/2 support is always enabled as it was in versions prior to `1.24.0` . 