### PR TITLE
Support for ports different from 443

### DIFF
--- a/fs_overlay/opt/certs_manager/lib/na_config.rb
+++ b/fs_overlay/opt/certs_manager/lib/na_config.rb
@@ -4,7 +4,7 @@ module NAConfig
   end
 
   def self.domains
-    (env_domains + auto_discovered_domains).uniq(&:name)
+    (env_domains + auto_discovered_domains).uniq {|d| d.name + ':' + d.port }
   end
 
   def self.stage

--- a/fs_overlay/opt/certs_manager/lib/nginx.rb
+++ b/fs_overlay/opt/certs_manager/lib/nginx.rb
@@ -18,7 +18,7 @@ module Nginx
   end
 
   def self.config_ssl(domain)
-    File.open("/etc/nginx/conf.d/#{domain.name}.ssl.conf", 'w') do |f|
+    File.open("/etc/nginx/conf.d/#{domain.name}_#{domain.port}.ssl.conf", 'w') do |f|
       f.write compiled_domain_config(domain, true)
     end
   end

--- a/fs_overlay/opt/certs_manager/models/domain.rb
+++ b/fs_overlay/opt/certs_manager/models/domain.rb
@@ -77,6 +77,10 @@ class Domain
     parsed_descriptor[:domain]
   end
 
+  def port
+    parsed_descriptor[:port] || '443'
+  end
+
   def env_format_name
     name.upcase.tr('^A-Z0-9', '_')
   end
@@ -190,7 +194,7 @@ class Domain
       regex = %r{
         ^
         (?:\[(?<ips>[0-9.:\/, ]*)\]\s*)?
-        (?:(?<user>[^:@\[\]]+)(?::(?<pass>[^@]*))?@)?(?<domain>[a-z0-9._\-]+?)
+        (?:(?<user>[^:@\[\]]+)(?::(?<pass>[^@]*))?@)?(?<domain>[a-z0-9._\-]+?)(?:\:(?<port>\d+))?
         (?:
           \s*(?<mode>[-=]>)\s*
           (?<upstream_proto>https?:\/\/)?

--- a/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
+++ b/fs_overlay/var/lib/nginx-conf/default.ssl.conf.erb
@@ -7,9 +7,9 @@ upstream <%= domain.upstream_backend_name %> {
 <% end %>
 
 server {
-    listen 443 ssl;
+    listen <%= domain.port %> ssl;
     <% if ENV['LISTEN_IPV6'] && ENV['LISTEN_IPV6'].downcase == 'true' %>
-    listen [::]:443 ssl;
+    listen [::]:<%= domain.port %> ssl;
     <% end %>
     http2 on;
     


### PR DESCRIPTION
It allows to do configurations like:
```
environment:
  DOMAINS: >
    myserver.example.com:1443 -> http://localhost:8081,
    myserver.example.com:2443 -> http://localhost:8082
```